### PR TITLE
Fix documentation index links

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -29,8 +29,8 @@ This documentation provides a markdown representation of the SonarQube Web API.
 - [Project Pull Requests](project_pull_requests.md)
 - [Project Tags](project_tags.md)
 - [Projects](projects.md)
-- [Quality Gates](qualitygates.md)
-- [Quality Profiles](qualityprofiles.md)
+- [Quality Gates](quality_gates.md)
+- [Quality Profiles](quality_profiles.md)
 - [Rules](rules.md)
 - [Sources](sources.md)
 - [System](system.md)
@@ -38,7 +38,7 @@ This documentation provides a markdown representation of the SonarQube Web API.
 - [Users](users.md)
 - [Views](views.md)
 - [Webhooks](webhooks.md)
-- [Web Services](webservices.md)
+- [Web Services](web_services.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- update documentation index links to match existing filenames
- verify all Markdown links resolve to files in the documentation folder

## Testing
- python - <<'PY' ...


------
https://chatgpt.com/codex/tasks/task_e_68d09e9dd6888327837db2ca152380d3